### PR TITLE
Date time in transaction date and sort the transaction list by date a…

### DIFF
--- a/lib/src/helpers/transaction_helper.dart
+++ b/lib/src/helpers/transaction_helper.dart
@@ -66,7 +66,7 @@ class TransactionHelper {
   }
 
   static getGroupedTransactions(transactions, exchangeRate, baseCurrency) {
-    final groupedList = groupBy(transactions, (t) => (t as Transaction).transactionDate);
+    final groupedList = groupBy(transactions, (t) => (t as Transaction).transactionDate?.toIso8601String().split('T')[0]);   // group the transaction by the the date only (exclude the time)
     final formattedList = [];
     groupedList.forEach((key, value) {
       final obj = {

--- a/lib/src/models/transaction.dart
+++ b/lib/src/models/transaction.dart
@@ -1,4 +1,3 @@
-import 'package:intl/intl.dart';
 import 'package:flutter_xspend/src/isar/isar_service.dart';
 import 'package:isar/isar.dart';
 
@@ -120,6 +119,7 @@ class Transaction {
     final user = await User.currentLoggedIn();
     final isar = await IsarService().getDB();
     final result = await isar.transactions.filter().transactionDateBetween(startDate, endDate).and().user((q) => q.idEqualTo(user.id)).sortByTransactionDateDesc().findAll();
+    // print('== result = ${result.first.toMap()}');
     return result;
   }
 

--- a/lib/src/new_transaction/new_transaction_view.dart
+++ b/lib/src/new_transaction/new_transaction_view.dart
@@ -15,6 +15,7 @@ import 'package:flutter_xspend/src/models/user.dart';
 import 'package:flutter_xspend/src/models/transaction.dart';
 import 'package:flutter_xspend/src/bloc/transaction/transaction_bloc.dart';
 import 'package:flutter_xspend/src/utils/currency_util.dart';
+import 'package:flutter_xspend/src/utils/datetime_util.dart';
 
 class NewTransactionView extends StatefulWidget {
   const NewTransactionView({super.key});
@@ -37,6 +38,7 @@ class _NewTransactionViewState extends State<NewTransactionView> {
   bool isEdit = false;
   String? selectedTransactionId;
   bool isSending = false;
+  DateTime? defaultDate;
 
   @override
   void initState() {
@@ -54,6 +56,7 @@ class _NewTransactionViewState extends State<NewTransactionView> {
             selectedCategory = transaction.category.value;
             amount = transaction.amount.toString();
           });
+          defaultDate = transaction.transactionDate;
           amountController.text = CurrencyUtil.formatNumber(transaction.amount.toString());
           noteController.text = transaction.note;
         });
@@ -74,14 +77,13 @@ class _NewTransactionViewState extends State<NewTransactionView> {
     isSending = true;
     setState(() { errorMsg = ''; });
     const uuid = Uuid();
-    DateTime tDate = date!.copyWith(hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0);
     final transaction = Transaction()
                           ..id = isEdit ? selectedTransactionId : uuid.v4()
                           ..amount = double.parse(amount)
                           ..currencyType = currencyType
                           ..note = noteController.text
                           ..transactionType = selectedCategory?.transactionType
-                          ..transactionDate = tDate
+                          ..transactionDate = DateTimeUtil.isSameDate(date, defaultDate) ? defaultDate : date
                           ..synced = false
                           ..category.value = selectedCategory
                           ..user.value = await User.currentLoggedIn();

--- a/lib/src/new_transaction/transaction_date_picker.dart
+++ b/lib/src/new_transaction/transaction_date_picker.dart
@@ -17,7 +17,19 @@ class TransactionDatePicker extends StatelessWidget {
       lastDate: DateTime(2025),
     );
     if (pickedDate != null && pickedDate != selectedDate) {
-      updateSelectedDate(pickedDate);
+      final now = DateTime.now();
+      final selectedDateTime = DateTime(
+        pickedDate.year,
+        pickedDate.month,
+        pickedDate.day,
+        now.hour,
+        now.minute,
+        now.second,
+        now.millisecond,
+        now.microsecond
+      );
+
+      updateSelectedDate(selectedDateTime);
     }
   }
 

--- a/lib/src/utils/datetime_util.dart
+++ b/lib/src/utils/datetime_util.dart
@@ -35,4 +35,10 @@ class DateTimeUtil {
     }
     return true;
   }
+
+  static isSameDate(DateTime? firstDate, DateTime? secDate) {
+    if (firstDate == null || secDate == null) return false;
+
+    return DateTime(firstDate.year, firstDate.month, firstDate.day).isAtSameMomentAs(DateTime(secDate.year, secDate.month, secDate.day));
+  }
 }


### PR DESCRIPTION
This pull request makes enhancements to the transaction list and the transaction form as listed below:
- Store the time in the transaction date
- Sort the transaction list by the transaction date and time
- Prevent updating the transaction time if the selected date is equal to the previous transaction date (when editing the transaction)