### PR TITLE
Make the budget progress bar color update based on the percentage

### DIFF
--- a/lib/src/budgets/budget_calculation_service.dart
+++ b/lib/src/budgets/budget_calculation_service.dart
@@ -10,9 +10,11 @@ class BudgetCalculationService {
 
   getProgress() {
     final double totalExpense = TransactionCalculationService.getTotalExpense(transactions, budget.currencyType, exchangeRates);
+    double percentage = totalExpense / budget.amount!;
+
     return {
       'expense': totalExpense,
-      'percentage': totalExpense / budget.amount!,
+      'percentage': percentage > 1 ? 1.0 : percentage,
       'remainAmount': budget.amount! - totalExpense,
       'amountEachDay': (budget.amount! - totalExpense) / _getNumberOfDays(),
       'remainingDays': _getNumberOfDays(),

--- a/lib/src/budgets/budget_controller.dart
+++ b/lib/src/budgets/budget_controller.dart
@@ -2,6 +2,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:flutter_xspend/src/models/budget.dart';
 import 'package:flutter_xspend/src/models/user.dart';
+import 'package:flutter_xspend/src/constants/colors.dart';
 
 class BudgetController {
   static bool isValidForm(name, amount, startDate, endDate) {
@@ -53,5 +54,15 @@ class BudgetController {
         callback?.call(budgets);
       });
     });
+  }
+
+  static getProgressBarColor(percentage) {
+    if (percentage < 0.5) {
+      return lightGreen;
+    }
+    else if (percentage < 0.75) {
+      return yellow;
+    }
+    return percentage < 0.85 ? orange : red;
   }
 }

--- a/lib/src/budgets/budget_list_item.dart
+++ b/lib/src/budgets/budget_list_item.dart
@@ -90,7 +90,7 @@ class BudgetListItem extends StatelessWidget {
                     MathUtil.getFormattedPercentage(progress['percentage']),
                     style: const TextStyle(color: Colors.black, fontWeight: FontWeight.bold),
                   ),
-                  progressColor: Colors.green,
+                  progressColor: BudgetController.getProgressBarColor(progress['percentage']),
                   backgroundColor: Colors.white,
                   padding: const EdgeInsets.all(0),
                 ),


### PR DESCRIPTION
This pull request makes the color of the budget progress bar updated based on the percentage of the bar.
- percentage < 50% : green
- percentage < 75% : yellow
- percentage < 85% : orange
- percentage > 85%: red