### PR TITLE
Fix android budget list warning

### DIFF
--- a/lib/src/bloc/budget/budget_bloc.dart
+++ b/lib/src/bloc/budget/budget_bloc.dart
@@ -1,9 +1,10 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:flutter_xspend/src/models/budget.dart';
+import 'budget_state.dart';
 
 part 'budget_event.dart';
-part 'budget_state.dart';
 
 class BudgetBloc extends Bloc<BudgetEvent, BudgetState> {
   BudgetBloc() : super(BudgetInitialState()) {
@@ -11,6 +12,6 @@ class BudgetBloc extends Bloc<BudgetEvent, BudgetState> {
   }
 
   void _onLoadBudget(LoadBudget event, Emitter<BudgetState> emit) {
-    emit(BudgetLoadedState(newBudgets: event.budgets));
+    emit(BudgetLoadedState(newBudgets: event.budgets, newTranList: event.tranList));
   }
 }

--- a/lib/src/bloc/budget/budget_event.dart
+++ b/lib/src/bloc/budget/budget_event.dart
@@ -1,10 +1,17 @@
 part of 'budget_bloc.dart';
 
-class BudgetEvent {
+class BudgetEvent extends Equatable {
   const BudgetEvent();
+
+  @override
+  List<Object> get props => [[], []];
 }
 
 class LoadBudget extends BudgetEvent {
-  const LoadBudget({ this.budgets = const <Budget> [] });
+  const LoadBudget({ this.budgets = const <Budget> [], this.tranList = const [] });
   final List<Budget> budgets;
+  final List tranList;
+
+  @override
+  List<Object> get props => [budgets, tranList];
 }

--- a/lib/src/bloc/budget/budget_state.dart
+++ b/lib/src/bloc/budget/budget_state.dart
@@ -1,15 +1,28 @@
-part of 'budget_bloc.dart';
+import 'package:equatable/equatable.dart';
 
-class BudgetState {
-  const BudgetState({ required this.budgets });
+import 'package:flutter_xspend/src/models/budget.dart';
+
+class BudgetState extends Equatable {
+  const BudgetState({ required this.budgets, required this.tranList });
   final List<Budget> budgets;
+  final List tranList;
+
+  @override
+  List<Object> get props => [budgets, tranList];
 }
 
 class BudgetInitialState extends BudgetState {
-  BudgetInitialState() : super(budgets: <Budget>[]);
+  BudgetInitialState() : super(budgets: <Budget>[], tranList: []);
+
+  @override
+  List<Object> get props => [[], []];
 }
 
 class BudgetLoadedState extends BudgetState {
-  BudgetLoadedState({ required this.newBudgets }) : super(budgets: newBudgets);
+  const BudgetLoadedState({ required this.newBudgets, required this.newTranList }) : super(budgets: newBudgets, tranList: newTranList);
   final List<Budget> newBudgets;
+  final List newTranList;
+
+  @override
+  List<Object> get props => [newBudgets, newTranList];
 }

--- a/lib/src/budgets/budget_calculation_service.dart
+++ b/lib/src/budgets/budget_calculation_service.dart
@@ -14,7 +14,7 @@ class BudgetCalculationService {
 
     return {
       'expense': totalExpense,
-      'percentage': percentage > 1 ? 1.0 : percentage,
+      'percentage': percentage,
       'remainAmount': budget.amount! - totalExpense,
       'amountEachDay': (budget.amount! - totalExpense) / _getNumberOfDays(),
       'remainingDays': _getNumberOfDays(),

--- a/lib/src/budgets/budget_controller.dart
+++ b/lib/src/budgets/budget_controller.dart
@@ -2,6 +2,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:flutter_xspend/src/models/budget.dart';
 import 'package:flutter_xspend/src/models/user.dart';
+import 'package:flutter_xspend/src/models/transaction.dart';
 import 'package:flutter_xspend/src/constants/colors.dart';
 
 class BudgetController {
@@ -11,7 +12,13 @@ class BudgetController {
 
   static loadBudgets(callback) async {
     final List<Budget> budgets = await Budget.getAllOfCurrentUser();
-    callback?.call(budgets);
+    List tranList = [];
+
+    for (Budget budget in budgets) {
+      final transactions = await Transaction.getAllByDurationType('custom', budget.startDate.toString(), budget.endDate.toString());
+      tranList.add(transactions);
+    }
+    callback?.call(budgets, tranList);
   }
 
   static create(name, amount, startDate, endDate, currencyType, callback) async {
@@ -26,8 +33,10 @@ class BudgetController {
                     ..user.value = await User.currentLoggedIn();
 
     Budget.create(budget);
-    loadBudgets((budgets) {
-      callback?.call(budgets);
+    Future.delayed(const Duration(milliseconds: 100), () {
+      loadBudgets((budgets, tranList) {
+        callback?.call(budgets, tranList);
+      });
     });
   }
 
@@ -41,8 +50,8 @@ class BudgetController {
     };
     Budget.update(id, params);
     Future.delayed(const Duration(milliseconds: 100), () {
-      loadBudgets((budgets) {
-        callback?.call(budgets);
+      loadBudgets((budgets, tranList) {
+        callback?.call(budgets, tranList);
       });
     });
   }
@@ -50,8 +59,8 @@ class BudgetController {
   static delete(String id, callback) {
     Budget.deleteById(id);
     Future.delayed(const Duration(milliseconds: 100), () {
-      loadBudgets((budgets) {
-        callback?.call(budgets);
+      loadBudgets((budgets, tranList) {
+        callback?.call(budgets, tranList);
       });
     });
   }

--- a/lib/src/budgets/budget_list.dart
+++ b/lib/src/budgets/budget_list.dart
@@ -3,8 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:flutter_xspend/src/bloc/exchange_rate/exchange_rate_bloc.dart';
 import 'package:flutter_xspend/src/constants/colors.dart';
-import 'package:flutter_xspend/src/models/budget.dart';
-import 'package:flutter_xspend/src/models/transaction.dart';
 import 'package:flutter_xspend/src/bloc/budget/budget_bloc.dart';
 import 'budget_calculation_service.dart';
 import 'budget_empty_message.dart';
@@ -24,20 +22,8 @@ class _BudgetListState extends State<BudgetList> {
   @override
   void initState() {
     super.initState();
-    BudgetController.loadBudgets((budgets) {
-      context.read<BudgetBloc>().add(LoadBudget(budgets: budgets));
-      loadTransactions(budgets);
-    });
-  }
-
-  void loadTransactions(budgets) async {
-    List tranList = [];
-    for (Budget budget in budgets) {
-      final transactions = await Transaction.getAllByDurationType('custom', budget.startDate.toString(), budget.endDate.toString());
-      tranList.add(transactions);
-    }
-    setState(() {
-      transactionList = tranList;
+    BudgetController.loadBudgets((budgets, tranList) {
+      context.read<BudgetBloc>().add(LoadBudget(budgets: budgets, tranList: tranList));
     });
   }
 
@@ -48,7 +34,7 @@ class _BudgetListState extends State<BudgetList> {
 
     Widget listItem(index) {
       final budget = budgetState.budgets[index];
-      final budgetCal = BudgetCalculationService(budget, transactionList[index], state.exchangeRate);
+      final budgetCal = BudgetCalculationService(budget, budgetState.tranList[index], state.exchangeRate);
       final Map<String, dynamic> progress = budgetCal.getProgress();
 
       return Column(
@@ -56,8 +42,8 @@ class _BudgetListState extends State<BudgetList> {
           BudgetListItem(
             budget: budget,
             progress: progress,
-            reloadBudgets: (newBudgets) {
-              context.read<BudgetBloc>().add(LoadBudget(budgets: newBudgets));
+            reloadBudgets: (newBudgets, newTranList) {
+              context.read<BudgetBloc>().add(LoadBudget(budgets: newBudgets, tranList: newTranList));
             }
           ),
           const Divider(color: grey, height: 1)
@@ -65,20 +51,15 @@ class _BudgetListState extends State<BudgetList> {
       );
     }
 
-    if (budgetState.budgets.isEmpty || transactionList.isEmpty) {
+    if (budgetState.budgets.isEmpty) {
       return const BudgetEmptyMessage();
     }
 
-    return BlocListener<BudgetBloc, BudgetState>(
-      listener: (context, state) {
-        loadTransactions(state.budgets);
-      },
-      child: ListView.builder(
-        itemCount: budgetState.budgets.length,
-        itemBuilder: (context, index) {
-          return listItem(index);
-        }
-      ),
+    return ListView.builder(
+      itemCount: budgetState.budgets.length,
+      itemBuilder: (context, index) {
+        return listItem(index);
+      }
     );
   }
 }

--- a/lib/src/budgets/budget_list.dart
+++ b/lib/src/budgets/budget_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:flutter_xspend/src/bloc/exchange_rate/exchange_rate_bloc.dart';
 import 'package:flutter_xspend/src/constants/colors.dart';
+import 'package:flutter_xspend/src/constants/spacing_constant.dart';
 import 'package:flutter_xspend/src/bloc/budget/budget_bloc.dart';
 import 'budget_calculation_service.dart';
 import 'budget_empty_message.dart';
@@ -56,6 +57,7 @@ class _BudgetListState extends State<BudgetList> {
     }
 
     return ListView.builder(
+      padding: const EdgeInsets.only(bottom: listPaddingBottom),
       itemCount: budgetState.budgets.length,
       itemBuilder: (context, index) {
         return listItem(index);

--- a/lib/src/budgets/budget_list_item.dart
+++ b/lib/src/budgets/budget_list_item.dart
@@ -18,15 +18,15 @@ class BudgetListItem extends StatelessWidget {
 
   final Budget budget;
   final Map<String, dynamic> progress;
-  final void Function(List<Budget> newBudgets) reloadBudgets;
+  final void Function(List<Budget> newBudgets, List tranList) reloadBudgets;
 
   void showDeleteConfirmation(BuildContext context) {
     DeleteConfirmationBottomSheet(
       title: AppLocalizations.of(context)!.deleteBudget,
       description: AppLocalizations.of(context)!.areYouSureToDeleteThisBudget,
       onConfirm: () {
-        BudgetController.delete(budget.id!, (budgets) {
-          reloadBudgets(budgets);
+        BudgetController.delete(budget.id!, (budgets, tranList) {
+          reloadBudgets(budgets, tranList);
         });
       }
     ).showBottomSheet(context);

--- a/lib/src/budgets/budget_list_item.dart
+++ b/lib/src/budgets/budget_list_item.dart
@@ -34,6 +34,70 @@ class BudgetListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget spendInfo() {
+      return RichText(
+        text: TextSpan(
+          text: AppLocalizations.of(context)!.youCanSpend,
+          style: TextStyle(fontSize: xsFontSize, color: pewter),
+          children: <TextSpan>[
+            TextSpan(
+              text: CurrencyUtil.getCurrencyFormat(progress['amountEachDay'], budget.currencyType),
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontSize: xsFontSize,
+                color: pewter,
+                fontWeight: FontWeight.w900
+              ),
+            ),
+            TextSpan(text: AppLocalizations.of(context)!.eachDayForTheRestOfPeriod(progress['remainingDays'])),
+          ],
+        ),
+      );
+    }
+
+    Widget amountInfo() {
+      if (progress['expense'] > budget.amount) {
+        return  RichText(
+          text: TextSpan(
+            text: AppLocalizations.of(context)!.spendingOverBudget,
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+              fontSize: 14,
+              color: red,
+              fontWeight: FontWeight.w900
+            ),
+            children:<TextSpan> [
+              TextSpan(
+                text: AppLocalizations.of(context)!.amountSpent(
+                  CurrencyUtil.getCurrencyFormat(progress['expense'], budget.currencyType),
+                  CurrencyUtil.getCurrencyFormat(budget.amount, budget.currencyType)
+                ),
+                style: const TextStyle(color: red, fontFamily: 'KantumruyPro')
+              ),
+            ],
+          ),
+        );
+      }
+
+      return  RichText(
+        text: TextSpan(
+          text: CurrencyUtil.getCurrencyFormat(progress['remainAmount'], budget.currencyType),
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            fontSize: 14,
+            color: primary,
+            fontWeight: FontWeight.w900
+          ),
+          children:<TextSpan> [
+            TextSpan(
+              text: AppLocalizations.of(context)!.budgetSpendRecommendation(
+                CurrencyUtil.getCurrencyFormat(budget.amount, budget.currencyType),
+                CurrencyUtil.getCurrencyFormat(progress['expense'], budget.currencyType)
+              ),
+              style: const TextStyle(color: primary, fontFamily: 'KantumruyPro')
+            ),
+          ],
+        ),
+      );
+    }
+
     Widget listItem() {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
@@ -42,50 +106,18 @@ class BudgetListItem extends StatelessWidget {
           children: [
             Text(budget.name!, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontSize: 16)),
             const SizedBox(height: 8),
-            RichText(
-              text: TextSpan(
-                text: CurrencyUtil.getCurrencyFormat(progress['remainAmount'], budget.currencyType),
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontSize: 14,
-                  color: primary,
-                  fontWeight: FontWeight.w900
-                ),
-                children:<TextSpan> [
-                  TextSpan(
-                    text: AppLocalizations.of(context)!.budgetSpendRecommendation(
-                      CurrencyUtil.getCurrencyFormat(budget.amount, budget.currencyType),
-                      CurrencyUtil.getCurrencyFormat(progress['expense'], budget.currencyType)
-                    ),
-                    style: const TextStyle(color: primary, fontFamily: 'KantumruyPro')
-                  ),
-                ],
-              ),
-            ),
+            amountInfo(),
             const SizedBox(height: 4),
-            RichText(
-              text: TextSpan(
-                text: AppLocalizations.of(context)!.youCanSpend,
-                style: TextStyle(fontSize: xsFontSize, color: pewter),
-                children: <TextSpan>[
-                  TextSpan(
-                    text: CurrencyUtil.getCurrencyFormat(progress['amountEachDay'], budget.currencyType),
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontSize: xsFontSize,
-                      color: pewter,
-                      fontWeight: FontWeight.w900
-                    ),
-                  ),
-                  TextSpan(text: AppLocalizations.of(context)!.eachDayForTheRestOfPeriod(progress['remainingDays'])),
-                ],
-              ),
-            ),
+            if (progress['remainingDays'] > 0 && progress['expense'] < budget.amount)
+              spendInfo(),
+
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 8),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(6),
                 child: LinearPercentIndicator(
                   lineHeight: 24,
-                  percent: progress['percentage'],
+                  percent: progress['percentage'] > 1 ? 1.0 : progress['percentage'],
                   center: Text(
                     MathUtil.getFormattedPercentage(progress['percentage']),
                     style: const TextStyle(color: Colors.black, fontWeight: FontWeight.bold),

--- a/lib/src/budgets/new_budget_form.dart
+++ b/lib/src/budgets/new_budget_form.dart
@@ -58,20 +58,20 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
     if (_formKey.currentState!.validate() && isValid) {
       _formKey.currentState!.save();
       if (widget.budgetId != null) {
-        BudgetController.update(widget.budgetId, name, amount, startDate, endDate, selectedCurrency, (newBudgets) {
-          reloadBudgetList(newBudgets);
+        BudgetController.update(widget.budgetId, name, amount, startDate, endDate, selectedCurrency, (newBudgets, tranList) {
+          reloadBudgetList(newBudgets, tranList);
         });
       }
       else {
-        BudgetController.create(name, amount, startDate, endDate, selectedCurrency, (newBudgets) {
-          reloadBudgetList(newBudgets);
+        BudgetController.create(name, amount, startDate, endDate, selectedCurrency, (newBudgets, tranList) {
+          reloadBudgetList(newBudgets, tranList);
         });
       }
     }
   }
 
-  void reloadBudgetList(budgets) {
-    context.read<BudgetBloc>().add(LoadBudget(budgets: budgets));
+  void reloadBudgetList(budgets, tranList) {
+    context.read<BudgetBloc>().add(LoadBudget(budgets: budgets, tranList: tranList));
     Navigator.of(context).pop();
   }
 

--- a/lib/src/budgets/new_budget_form.dart
+++ b/lib/src/budgets/new_budget_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:flutter_xspend/src/constants/colors.dart';
 import 'package:flutter_xspend/src/shared/input_label_widget.dart';
@@ -39,6 +40,9 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
     if (widget.budgetId != null) {
       loadBudgetInfo();
     }
+    else {
+      loadDefaultCurrency();
+    }
   }
 
   void loadBudgetInfo() async {
@@ -52,6 +56,13 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
     });
     _nameController.text = budget.name!;
     _amountController.text = CurrencyUtil.formatNumber(budget.amount.toString());
+  }
+
+  void loadDefaultCurrency() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    setState(() {
+      selectedCurrency = prefs.getString('BASED_CURRENCY').toString();
+    });
   }
 
   void saveBudget() {
@@ -219,6 +230,8 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
                     },
                   ),
                   const SizedBox(height: 24),
+                  currencyPicker(),
+                  const SizedBox(height: 24),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
@@ -226,8 +239,6 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
                       datePicker('end', () { selectDate(endDate, 'end'); }),
                     ],
                   ),
-                  const SizedBox(height: 24),
-                  currencyPicker(),
                 ],
               ),
             ),

--- a/lib/src/budgets/new_budget_form.dart
+++ b/lib/src/budgets/new_budget_form.dart
@@ -99,25 +99,15 @@ class _NewBudgetFormState extends State<NewBudgetForm> {
       );
 
       if (pickedDate != null && !DateTimeUtil.isSameDate(pickedDate, selectedDate)) {
-        final now = DateTime.now();
-        final selectedDateTime = DateTime(
-          pickedDate.year,
-          pickedDate.month,
-          pickedDate.day,
-          now.hour,
-          now.minute,
-          now.second,
-          now.millisecond,
-          now.microsecond
-        );
         setState(() {
           if (type == 'start') {
-            startDate = selectedDateTime;
-            isValid = BudgetController.isValidForm(name, amount, selectedDateTime, endDate);
+            startDate = pickedDate;
+            isValid = BudgetController.isValidForm(name, amount, pickedDate, endDate);
           }
           else {
-            endDate = selectedDateTime;
-            isValid = BudgetController.isValidForm(name, amount, startDate, selectedDateTime);
+            final newEndDate = DateTime(pickedDate.year, pickedDate.month, pickedDate.day, 23, 59, 59, 999);
+            endDate = newEndDate;
+            isValid = BudgetController.isValidForm(name, amount, startDate, newEndDate);
           }
         });
       }

--- a/lib/src/constants/spacing_constant.dart
+++ b/lib/src/constants/spacing_constant.dart
@@ -1,1 +1,2 @@
 const double androidAppBarPaddingTop = 40;
+const double listPaddingBottom = 70;

--- a/lib/src/localization/app_en.arb
+++ b/lib/src/localization/app_en.arb
@@ -98,5 +98,7 @@
   "selectDate": "Select date",
   "deleteBudget": "Delete Budget",
   "areYouSureToDeleteThisBudget": "Are you sure to delete this budget?",
-  "editBudget": "Edit Budget"
+  "editBudget": "Edit Budget",
+  "spendingOverBudget": "Spending over budget ",
+  "amountSpent": "(spent {amount} / budget {budget})"
 }

--- a/lib/src/localization/app_en.arb
+++ b/lib/src/localization/app_en.arb
@@ -85,7 +85,7 @@
   "noBudgetCreated": "No budget created",
   "budgetSpendRecommendation": " left out of {a} ({b} spent)",
   "youCanSpend": "You can spend ",
-  "eachDayForTheRestOfPeriod": " each day for the rest of period. ({day} days left)",
+  "eachDayForTheRestOfPeriod": " each day for the rest of period. ({count, plural, =1{1 day} other{{count} days}} left)",
   "createNewBudget": "Create New Budget",
   "budgetName": "Budget name",
   "pleaseEnterBudgetName": "Please enter budget name",

--- a/lib/src/localization/app_km.arb
+++ b/lib/src/localization/app_km.arb
@@ -99,6 +99,6 @@
   "deleteBudget": "លុបកញ្ចប់ថវិកា",
   "areYouSureToDeleteThisBudget": "តើអ្នកពិតជាចង់លុបកញ្ចប់ថវិកានេះ?",
   "editBudget": "កែប្រែកញ្ចប់ថវិកា",
-  "spendingOverBudget": "ចំណាយលើសថវិកា",
+  "spendingOverBudget": "ចំណាយលើសថវិកា ",
   "amountSpent": "(បានចាយ {amount} / ថវិកា {budget})"
 }

--- a/lib/src/localization/app_km.arb
+++ b/lib/src/localization/app_km.arb
@@ -98,5 +98,7 @@
   "selectDate": "សូមជ្រើសរើសថ្ងៃ",
   "deleteBudget": "លុបកញ្ចប់ថវិកា",
   "areYouSureToDeleteThisBudget": "តើអ្នកពិតជាចង់លុបកញ្ចប់ថវិកានេះ?",
-  "editBudget": "កែប្រែកញ្ចប់ថវិកា"
+  "editBudget": "កែប្រែកញ្ចប់ថវិកា",
+  "spendingOverBudget": "ចំណាយលើសថវិកា",
+  "amountSpent": "(បានចាយ {amount} / ថវិកា {budget})"
 }

--- a/lib/src/localization/app_km.arb
+++ b/lib/src/localization/app_km.arb
@@ -85,7 +85,7 @@
   "noBudgetCreated": "មិនមានកញ្ចប់ថវិកា",
   "budgetSpendRecommendation": " នៅសល់ពី {a} (បានចាយ {b})",
   "youCanSpend": "អ្នកអាចចាយ ",
-  "eachDayForTheRestOfPeriod": " រាល់ថ្ងៃក្នុងរយៈពេលដែលនៅសល់។ ({day} ថ្ងៃនៅសល់)",
+  "eachDayForTheRestOfPeriod": " រាល់ថ្ងៃក្នុងរយៈពេលដែលនៅសល់។ ({count, plural, =1{1 ថ្ងៃ} other{{count} ថ្ងៃ}} នៅសល់)",
   "createNewBudget": "បង្កើតកញ្ចប់ថវិកាថ្មី",
   "budgetName": "ឈ្មោះកញ្ចប់ថវិកា",
   "pleaseEnterBudgetName": "សូមបញ្ចូលឈ្មោះកញ្ចប់ថវិកា",

--- a/lib/src/models/budget.dart
+++ b/lib/src/models/budget.dart
@@ -53,7 +53,21 @@ class Budget {
   static getAllOfCurrentUser() async {
     final user = await User.currentLoggedIn();
     final isar = await IsarService().getDB();
-    return await isar.budgets.filter().user((q) => q.idEqualTo(user.id)).sortByStartDate().findAll();
+    List budgets = await isar.budgets.filter().user((q) => q.idEqualTo(user.id)).sortByStartDate().findAll();
+    final today = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+
+    // This code will sort the budgets that passed to the bottom of the list
+    // The budgets..sort will sort and return the sorted array
+    return budgets..sort((a, b) {
+      return a.endDate.isBefore(today) ? 1 : -1;
+    });
+
+    // The budgets.sort will not return the sorted array, it is updating the budgets, so we need to return the budgets at the end
+    // budgets.sort((a, b) {
+    //   return a.endDate.isBefore(today) ? 1 : -1;
+    // });
+
+    // return budgets;
   }
 
   static findById(String id) async {

--- a/lib/src/models/transaction.dart
+++ b/lib/src/models/transaction.dart
@@ -115,6 +115,8 @@ class Transaction {
       DateTime startOfNextYear = DateTime(now.year + 1, 1, 1);
       endDate = startOfNextYear.subtract(const Duration(days: 1));
     }
+    // set the time of the day to 23:59 in order to be able to query the transactions on the endDate
+    endDate = DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59, 999);
 
     final user = await User.currentLoggedIn();
     final isar = await IsarService().getDB();

--- a/lib/src/new_transaction/transaction_category_bottom_sheet.dart
+++ b/lib/src/new_transaction/transaction_category_bottom_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -67,7 +68,7 @@ class _TransactionCategoryBottomSheetState extends State<TransactionCategoryBott
             onPressed: () { switchType(type); },
             icon: Icon(transactionTypes[type]!['icon'] as IconData?, color: color['label']),
             label: Padding(
-              padding: EdgeInsets.only(top: LocalizationService.currentLanguage == 'km' ? 4 : 0),
+              padding: EdgeInsets.only(top: (LocalizationService.currentLanguage == 'km' && Platform.isIOS) ? 4 : 0),
               child: Text(
                 label,
                 style: TextStyle(color: color['label']),

--- a/lib/src/shared/bottom_sheet/delete_confirmation_bottom_sheet.dart
+++ b/lib/src/shared/bottom_sheet/delete_confirmation_bottom_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -27,7 +28,7 @@ class DeleteConfirmationBottomSheet extends StatefulWidget {
 class _DeleteConfirmationBottomSheetState extends State<DeleteConfirmationBottomSheet> {
   Widget label(String text, Color color) {
     return Padding(
-            padding: EdgeInsets.only(top: LocalizationService.currentLanguage == 'km' ? 4 : 0),
+            padding: EdgeInsets.only(top: (LocalizationService.currentLanguage == 'km' && Platform.isIOS) ? 4 : 0),
             child: Text(text, style: TextStyle(color: color)),
           );
   }

--- a/lib/src/shared/transaction_list/transaction_list.dart
+++ b/lib/src/shared/transaction_list/transaction_list.dart
@@ -12,6 +12,7 @@ import 'package:flutter_xspend/src/bloc/exchange_rate/exchange_rate_bloc.dart';
 import 'package:flutter_xspend/src/bloc/base_currency/base_currency_bloc.dart';
 import 'package:flutter_xspend/src/utils/initial_util.dart';
 import 'package:flutter_xspend/src/constants/font_size.dart';
+import 'package:flutter_xspend/src/constants/spacing_constant.dart';
 
 class TransactionList extends StatefulWidget {
   const TransactionList({super.key, required this.hasLineChart, required this.isSlideable});
@@ -98,7 +99,7 @@ class _TransactionListState extends State<TransactionList> {
             ),
           )
         ],
-        const SliverPadding(padding: EdgeInsets.only(bottom: 62)),
+        const SliverPadding(padding: EdgeInsets.only(bottom: listPaddingBottom)),
       ],
     );
   }


### PR DESCRIPTION
This pull request fixes the issue and makes some enhancements to the budget list and budget form screen:
- Fix the issue where the budget list is not updating when a new budget is created for the first time by moving the transactions of the budget to store in the state of the budget bloc
- Sort the budget list by moving the expired budget to the bottom of the list
- Add padding-bottom to the budget list to prevent the last item get blocked by the add button
- Fix the query to get the transaction list by setting the time of the endDate to 23:59 to be able to query the transaction of the endDate
- Set the selected currency to the base currency by default when creating a new budget and move the currency picker to under the amount text field
- Fix the padding-top of the Khmer label inside the button on Android devices
- Show a spending over budget message when the budget gets overspent